### PR TITLE
Fix issue #17. Sometime when script execution is requested and retrie…

### DIFF
--- a/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/ScriptExecutionStorage/PollingScriptExecutionPersister.cs
+++ b/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/ScriptExecutionStorage/PollingScriptExecutionPersister.cs
@@ -25,6 +25,14 @@ namespace VMware.ScriptRuntimeService.APIGateway.ScriptExecutionStorage {
       public void Start(IRunspace runspaceClient, string scriptId, string scriptName, IScriptExecutionStoreProvider scriptExecutionWriter) {
          int maxGetLastScriptFailures = 3;
          int lastScriptFailures = 0;
+
+         // Initialize scriptExecutionWriter with running script execution with Id, Name, and State
+         scriptExecutionWriter.WriteScriptExecution(new NamedScriptExecution {
+            Name = scriptName,
+            Id = scriptId,
+            State = ScriptState.Running
+         });
+
          Task.Run(() => {
             IScriptExecutionResult scriptExecutionResult = null;
             do {


### PR DESCRIPTION
…ved immediately afterwards GET API return Not Found with internal error code 1040

Testing done:
Ran the client script that reproduces the issue three times

```powershell
PS C:\Users\dmilov> C:\Temp\bugreproduce.ps1 -SRSAddress 10.23.82.191 -Usename 'administrator@vsphere.local'
Login SRS                                                                                                               Create Runspace                                                                                                         Wait runspace to become ready                                                                                           Loop script execution and script execution retrieval                                                                    Attempt: 1
Attempt: 2
Attempt: 3
Attempt: 4
Attempt: 5
Attempt: 6
Attempt: 7
Attempt: 8
Attempt: 9
Attempt: 10
Attempt: 11
Attempt: 12
Attempt: 13
Attempt: 14
Attempt: 15
Attempt: 16
Attempt: 17
Attempt: 18
Attempt: 19
Attempt: 20
PS C:\Users\dmilov> C:\Temp\bugreproduce.ps1 -SRSAddress 10.23.82.191 -Usename 'administrator@vsphere.local'
Login SRS                                                                                                               Create Runspace                                                                                                         Wait runspace to become ready                                                                                           Loop script execution and script execution retrieval                                                                    Attempt: 1
Attempt: 2
Attempt: 3
Attempt: 4
Attempt: 5
Attempt: 6
Attempt: 7
Attempt: 8
Attempt: 9
Attempt: 10
Attempt: 11
Attempt: 12
Attempt: 13
Attempt: 14
Attempt: 15
Attempt: 16
Attempt: 17
Attempt: 18
Attempt: 19
Attempt: 20
PS C:\Users\dmilov> C:\Temp\bugreproduce.ps1 -SRSAddress 10.23.82.191 -Usename 'administrator@vsphere.local' 
Login SRS
Create Runspace
Wait runspace to become ready
Loop script execution and script execution retrieval
Attempt: 1
Attempt: 2
Attempt: 3
Attempt: 4
Attempt: 5
Attempt: 6
Attempt: 7
Attempt: 8
Attempt: 9
Attempt: 10
Attempt: 11
Attempt: 12
Attempt: 13
Attempt: 14
Attempt: 15
Attempt: 16
Attempt: 17
Attempt: 18
Attempt: 19
Attempt: 20
```