### PR TITLE
Topic/dmilov/disconnect on runspace delete

### DIFF
--- a/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/SystemScripts/PCLIScripts/DisconnectAllServers.ps1
+++ b/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/SystemScripts/PCLIScripts/DisconnectAllServers.ps1
@@ -1,0 +1,1 @@
+Disconnect-VIServer -Server * -Confirm:$false

--- a/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/SystemScripts/PCLIScriptsReader.cs
+++ b/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/SystemScripts/PCLIScriptsReader.cs
@@ -27,6 +27,8 @@ namespace VMware.ScriptRuntimeService.APIGateway.SystemScripts {
       #region Public Interface
       public static string ConnectByStringSamlToken => File.ReadAllText(GetFullPath("ConnectByStringSamlToken.ps1"));
 
+      public static string DisconnectAllServers => File.ReadAllText(GetFullPath("DisconnectAllServers.ps1"));
+
       public static IEnumerable<ArgumentScriptTemplate> ListArgumentTransformationScriptNames() {
          var scriptsDir = GetFullPath(ArgumentScriptsDirName);
          foreach (var filePath in Directory.GetFiles(scriptsDir)) {

--- a/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/VMware.ScriptRuntimeService.APIGateway.csproj
+++ b/src/Endpoint/VMware.ScriptRuntimeService.APIGateway/VMware.ScriptRuntimeService.APIGateway.csproj
@@ -309,6 +309,9 @@
     <None Update="SystemScripts\PCLIScripts\ArgumentTransformationScripts\vm-by-id-server-name.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="SystemScripts\PCLIScripts\DisconnectAllServers.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="SystemScripts\PCLIScripts\ConnectByStringSamlToken.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/vSphereIntegrationLibraries/VMware.ScriptRuntimeService.Sts/STSClient.cs
+++ b/src/vSphereIntegrationLibraries/VMware.ScriptRuntimeService.Sts/STSClient.cs
@@ -140,7 +140,8 @@ namespace VMware.ScriptRuntimeService.Sts
             TokenType = "urn:oasis:names:tc:SAML:2.0:assertion",
             KeyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer",
             Lifetime = null,
-            DelegatableSpecified = false
+            Delegatable = true,
+            DelegatableSpecified = true
          };
 
          // Security Token Request Authorization Header
@@ -609,7 +610,8 @@ namespace VMware.ScriptRuntimeService.Sts
             TokenType = "urn:oasis:names:tc:SAML:2.0:assertion",
             KeyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer",
             Lifetime = null,
-            DelegatableSpecified = false
+            Delegatable = true,
+            DelegatableSpecified = true
          };
 
          // Security Token Request Authorization Header


### PR DESCRIPTION
Fixes issue #16 and issue #13 

Testing done:

Ran all API integration tests, results is

```
Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\ArgumentScriptsAPI.Tests.ps1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     Describing Arguments Scripts API Tests                                                                                                                                                                                                            Context Retrieval and Generation API Workflow                                                                             [+] Lists argument script templates 47ms                                                                                [+] Gets argument script template 25ms                                                                                  [+] Generates argument script by one id and one server 20ms
      [+] Generates argument script by two ids and one server 24ms
      [+] Generates argument script by one id and two servers 30ms
      [+] Requests generation of argument script that doesn`t exist 21ms

Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\Authentication.Tests.ps1

  Describing SIGNAuthenticationAPITests

    Context Login
      [+] Service To Service Login with SIGN Authnetication and delegated token 813ms

  Describing BASICAuthenticationAPITests

    Context Login
      [+] User creates SRS session with username and password 181ms
      [+] User tries to create SRS session with invalid username and password 221ms

  Describing Authentication API Tests

    Context Logout API
      [+] Logout closes the session 805ms
      [+] Logout shuts down all runspaces in maximum 2 minutes 121.59s

Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\PowerCLIScripts.Tests.ps1

  Describing PowerCLI Scripts Tests

    Context PowerCLI Scripts API Workflow                                                                                     [+] Connects PowerCLI to VC and lists vi accounts with Get-VIAccount cmdlet 2.17s                                       [+] Tests Multiple PowerCLI scripts in same runspace produce text output 3.18s                                          [+] Renames Datacenter using script parameters retrieved with argument transformation script 3.25s                      [+] Runs CRUD10Datacenters PowerCLI Script 6.3s

Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\RunspacesAPI.Tests.ps1

  Describing Runspaces API Tests

    Context Runspaces API Workflow                                                                                            [+] Create Runspace should return object with Id 276ms                                                                  [+] Get Runspace by Id should return object with desired 377ms                                                          [+] List Runspace should return all runspaces 820ms                                                                     [+] Delete Runspace should remove runspace 337ms
      [+] Delete Runspace for connected runspace generates disconnect script execution 2.11s
      [+] Gets Runspace taht doesn`t exist 66ms

    Context Max Number Of Runspaces
      [+] Requests create runspaces until maximum allowed runspaces are reached 3.97s
                                                                                                                        Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\ScriptsAPI.Tests.ps1                                                                                                                            Describing Scripts API Tests                                                                                          
    Context Scripts API Workflow
      [+] Starts named script 2.51s
      [+] Runs "Write-Output "Test Text"" script 1.1s
      [+] Get script by Id 1.17s
      [+] List scripts 39ms
      [+] Gets Script Streams 1.24s
      [+] Gets Script Objects 1.11s
      [+] Gets Script Text 1.07s
      [+] Cancels Long Running Script 4.17s
      [+] Tests Script Failure 1.07s

    Context Negative Scenarios for Scripts API
      [+] Requests a script execution to unexistent runspaces 53ms
      [+] Request script execution before previous script in the runspace has finished 7.02s
      [+] Gets script that doesn`t exist 22ms

Executing script C:\git-repos\script-runtime-service-for-vsphere\test\api-integration-tests\tests\ScriptsWithParametersAPI.Tests.ps1

  Describing Scripts with Parameters API Tests

    Context Scripts with Parameters API Workflow
      [+] Executes script with one parameter passed by value 2.43s
      [+] Executes script with one parameter passed by value 1.08s
      [+] Executes script with one parameter passed by scrtip 1.22s
Tests completed in 203.67s
Tests Passed: 37, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```