### PR TITLE
Add configurable setting to create ingress with or without tls rules.…

### DIFF
--- a/helmchart/templates/srs-app.yaml
+++ b/helmchart/templates/srs-app.yaml
@@ -207,6 +207,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.allow-http: "false"
 spec:
+  {{ if eq .Values.srs.configure_ingress_tls true }}
   tls:
   - hosts:
     - {{ required "Specify SRS service hostname" .Values.srs.service.hostname  }}
@@ -214,6 +215,10 @@ spec:
   rules:
   - host: {{ required "Specify SRS service hostname" .Values.srs.service.hostname  }}
     http:
+  {{ else }}
+  rules:
+  - http:
+  {{ end }}
       paths:
       - path: /
         backend:

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -89,3 +89,8 @@ srs:
     ## Size of the Persistent Volume
     ##
     #storage_size: 200Mi
+  ##
+  ## Indicates whether to configure TLS termination on the SRS Ingress resource or not.
+  ## If this values is set to false, TLS is not configured on the ingress resource. The traffic to the service depends on the configured Ingress Controller of the cluster
+  ##
+  configure_ingress_tls: true


### PR DESCRIPTION
… By deafult tls rule is created. User can override the default value to let ingress controller route to the service without tls terminartion